### PR TITLE
Remove license hyperlink

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,7 +180,7 @@
           </div>
           <div class="contact-item">
             <span class="contact-label">License #</span>
-            <span class="contact-value">02248734</span>
+            <span class="contact-value" data-license>02248734</span>
           </div>
         </div>
         <div class="contact-row">

--- a/styles.css
+++ b/styles.css
@@ -62,6 +62,7 @@ h1{font-size:24px;margin:12px 0 6px}
 .contact-item{flex:1;text-align:center;padding:14px 18px;background:#fff;border-radius:6px;font-size:14px;box-sizing:border-box;border:1px solid #e5e7eb}
 .contact-label{color:var(--muted);font-size:12px;margin-bottom:3px;display:block;text-transform:uppercase;letter-spacing:0.3px}
 .contact-value{font-weight:600;margin:0;font-size:13px}
+.contact-value[data-license]{cursor:default;pointer-events:none;text-decoration:none;color:inherit}
 .office-info{margin:0;padding:20px;background:#fafbfc;border-radius:8px;text-align:center;max-width:480px;margin-left:auto;margin-right:auto;border:1px solid #e5e7eb}
 .office-title{font-weight:600;margin-bottom:8px;color:var(--muted);font-size:13px;text-transform:uppercase}
 .office-address{margin:0;font-size:14px;line-height:1.4}


### PR DESCRIPTION
Remove hyperlink behavior from the license number by adding a data attribute and corresponding CSS rules.

Although the license number was rendered as plain text in the HTML, it was appearing as a clickable element on the webpage. This PR adds specific CSS rules to the element, targeted by a new `data-license` attribute, to explicitly disable any pointer events, change the cursor, and remove text decoration, ensuring it is not interactive.

---
<a href="https://cursor.com/background-agent?bcId=bc-5f7f7e00-2275-4aed-a239-84a29d504ec9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5f7f7e00-2275-4aed-a239-84a29d504ec9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

